### PR TITLE
Fixes compatibility with Numpy 1.24.

### DIFF
--- a/faxitron/im_util.py
+++ b/faxitron/im_util.py
@@ -36,7 +36,7 @@ def histeq_np_create(npim, nbr_bins=256, verbose=0):
     # get image histogram
     flat = npim.flatten()
     verbose and print('flat', flat)
-    imhist, bins = np.histogram(flat, nbr_bins, normed=True)
+    imhist, bins = np.histogram(flat, nbr_bins)
     verbose and print('imhist', imhist)
     verbose and print('imhist', bins)
     cdf = imhist.cumsum()  #cumulative distribution function
@@ -95,10 +95,10 @@ def average_imgs(imgs, scalar=None):
         scalar = 1.0
     scalar = scalar / len(imgs)
 
-    statef = np.zeros((height, width), np.float)
+    statef = np.zeros((height, width), float)
     for im in imgs:
         assert (width, height) == im.size
-        statef = statef + scalar * np.array(im, dtype=np.float)
+        statef = statef + scalar * np.array(im, dtype=float)
 
     return statef, npf2im(statef)
 
@@ -185,7 +185,7 @@ def dir2np(din, cal_dir=None, bpr=False):
             if badimg:
                 im = do_bpr(im, badimg)
 
-            npim = np.array(im, dtype=np.float)
+            npim = np.array(im, dtype=float)
             burst.append(np.ndarray.flatten(npim))
         if not burst:
             break
@@ -199,7 +199,7 @@ def average_npimgs(npims):
     width = len(npims[0])
     height = len(npims)
 
-    statef = np.zeros((height, width), np.float)
+    statef = np.zeros((height, width), float)
     for npim in npims:
         statef = statef + npim 
 

--- a/ham_process.py
+++ b/ham_process.py
@@ -149,7 +149,7 @@ def run(dir_in,
         elif mode == "3":
             # raise ValueError("Images of type float must be between -1 and 1.")
             imnp = np.array(im_wip, dtype=np.uint16)
-            #imnp = np.ndarray.astype(imnp, dtype=np.float)
+            #imnp = np.ndarray.astype(imnp, dtype=float)
             print(np.ndarray.min(imnp), np.ndarray.max(imnp))
             imnp = 1.0 * imnp / 0xFFFF
             im_wip = im_util.npf2im(


### PR DESCRIPTION
This fixes compatibility with Numpy 1.24 by removing the deprecated `normed` parameter of `np.histogram` and substitutes a `float` type for the deprecated `np.float` type.

Should also work on 1.23, but not very old versions.  Fixes #12.